### PR TITLE
Removed magic-quotes check

### DIFF
--- a/fpdf.php
+++ b/fpdf.php
@@ -1039,9 +1039,6 @@ protected function _dochecks()
 	// Check mbstring overloading
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
-	// Ensure runtime magic quotes are disabled
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
 }
 
 protected function _checkoutput()


### PR DESCRIPTION
Since PHP 5.4 get_magic_quotes_runtime returns false and it is deprecated as of PHP 7.4