### PR TITLE
Fix warning on PHP8

### DIFF
--- a/fpdf.php
+++ b/fpdf.php
@@ -1655,7 +1655,7 @@ protected function _putfonts()
 		$this->fonts[$k]['n'] = $this->n+1;
 		$type = $font['type'];
 		$name = $font['name'];
-		if($font['subsetted'])
+		if(isset($font['subsetted']))
 			$name = 'AAAAAA+'.$name;
 		if($type=='Core')
 		{


### PR DESCRIPTION
Fixed the following warnings:
`Warning(E_WARNING): Undefined array key "subsetted" on [/path/to/vendor/setasign/fpdf/fpdf.php(1658)]`